### PR TITLE
normalize8baseDocumentsCreateItems

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cobuildlab/8base-utils",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -44,14 +44,14 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged"
+      "pre-commit": "npx lint-staged",
+      "pre-push:": "npm test"
     }
   },
   "lint-staged": {
     "*.js": [
       "prettier --write",
-      "tslint -p tsconfig.json --fix",
-      "git add"
+      "tslint -p tsconfig.json --fix"
     ]
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cobuildlab/8base-utils",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "This is package to deal with common scenarios working with 8base platform",
   "main": "lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/__tests__/files-test.ts
+++ b/src/__tests__/files-test.ts
@@ -1,5 +1,6 @@
 import {
   normalize8baseDocumentCreate,
+  normalize8baseDocumentsCreateItems,
   normalize8baseDocumentDeleteAndUpdate,
   normalize8baseDocumentsCreate, normalize8baseDocumentsDeleteAndUpdate
 } from "../files";
@@ -120,6 +121,73 @@ test("normalize8baseDocumentsCreate:", () => {
   const o10 = { a: [{ fileId: "<ID>" }] };
   expect(() => normalize8baseDocumentsCreate(o10, "a")).toThrowError(
     new ValidationError(`normalize8baseDocumentsCreate:currentValues: object is not a valid file as it doesn't contain a valid filename property.`)
+  );
+
+});
+
+test("normalize8baseDocumentsCreateItems:", () => {
+  expect(() => normalize8baseDocumentsCreateItems({}, "")).toThrowError(
+    new ValidationError(`normalize8baseDocumentsCreateItems:key: value: can't be blank, null or undefined.`)
+  );
+
+  const o0 = { a: null };
+  normalize8baseDocumentsCreateItems(o0, "a");
+  expect(o0).toEqual({});
+
+  const o1 = { a: { items: null } };
+  normalize8baseDocumentsCreateItems(o1, "a");
+  expect(o1).toEqual({});
+
+  const o2 = { a: { items: undefined } };
+  normalize8baseDocumentsCreateItems(o2, "a");
+  expect(o2).toEqual({});
+
+  const o3 = { a: { items: 0 }};
+  expect(() => normalize8baseDocumentsCreateItems(o3, "a")).toThrowError(
+    new ValidationError(
+      `normalize8baseDocumentsCreateItems:currentValues: object is not a List.`
+    )
+  );
+
+  const o4 = { a: { items: "something" } };
+  expect(() => normalize8baseDocumentsCreateItems(o4, "a")).toThrowError(
+    new ValidationError(
+      `normalize8baseDocumentsCreateItems:currentValues: object is not a List.`
+    )
+  );
+
+  const o5 = { a: { items: [] } };
+  normalize8baseDocumentsCreateItems(o5, "a");
+  expect(o5).toEqual({});
+
+  const o6 = { a: {items: [{ id: null }]} };
+  expect(() => normalize8baseDocumentsCreateItems(o6, "a")).toThrowError(
+    new ValidationError(`normalize8baseDocumentsCreateItems:currentValues: object is not a valid file as it doesn't contain a valid fileId property.`)
+  );
+
+  const o7 = { a: {items: { fileId: null }} };
+  expect(() => normalize8baseDocumentsCreateItems(o7, "a")).toThrowError(
+    new ValidationError(`normalize8baseDocumentsCreateItems:currentValues: object is not a List.`)
+  );
+
+  const o8 = { a: {items: [{ fileId: "<ID>", filename: "<FILENAME>" }]} };
+  normalize8baseDocumentsCreateItems(o8, "a");
+  expect(o8).toEqual({ a: { create: [{ fileId: "<ID>", filename: "<FILENAME>" }] } });
+
+  const o9 = { a: {items: [{ fileId: "<ID1>", filename: "<FILENAME1>" }, { fileId: "<ID2>", filename: "<FILENAME2>" }]} };
+  normalize8baseDocumentsCreateItems(o9, "a");
+  expect(o9).toEqual({
+    a: {
+      create: [{ fileId: "<ID1>", filename: "<FILENAME1>" }, {
+        fileId: "<ID2>",
+        filename: "<FILENAME2>"
+      }]
+    }
+  });
+
+  const o10 = { a: {items: [{ fileId: "<ID>" }]} };
+  expect(() => normalize8baseDocumentsCreateItems(o10, "a")).toThrowError(
+    new ValidationError(`normalize8baseDocumentsCreateItems:currentValues: object is not a valid file as it doesn't contain a valid filename property.`)
   );
 
 });

--- a/src/files.ts
+++ b/src/files.ts
@@ -70,6 +70,50 @@ export const normalize8baseDocumentsCreate = (
   data[key] = { create: documents };
 };
 
+/**
+ * Helper to change non null keys to 8base 'create' reference for files.
+ * // USE this for { items: [] } models.
+ *
+ * WARNING: This function mutates the data.
+ * WARNING: This functions assumes that all 8base keys are strings
+ * @param {object} data - The Object to be Mutated.
+ * @param {string} key - The key in the Object.
+ */
+export const normalize8baseDocumentsCreateItems = (
+  data: Record<string, any>,
+  key: string
+) => {
+  _validateNullOrUndefinedOrBlank(key, "normalize8baseDocumentsCreateItems:key");
+
+  const value = data[key]
+
+  if (isNullOrUndefined(value)) {
+    delete data[key];
+    return;
+  }
+
+  const currentValues = value.items;
+  if (isNullOrUndefined(currentValues)) {
+    delete data[key];
+    return;
+  }
+
+  _validateFiles(currentValues, "normalize8baseDocumentsCreateItems:currentValues");
+
+  if (currentValues.length === 0) {
+    delete data[key];
+    return;
+  }
+
+  const documents: Record<string, any>[] = [];
+  for (const file of currentValues) {
+    _validateFile(file, "normalize8baseDocumentsCreateItems:file.fileId");
+    documents.push({ fileId: file.fileId, filename: file.filename  });
+  }
+
+  data[key] = { create: documents };
+};
+
 
 /**
  * Helper to update or delete one document key from an Object.


### PR DESCRIPTION
- Added new normalize for `{ items: [] }` models.
- Removed git add from lint staged, is not needed on new versions